### PR TITLE
bug fix for the EE Nells and specified that the 1st two cols of the noise files should be read in

### DIFF
--- a/bin/lensing.py
+++ b/bin/lensing.py
@@ -25,13 +25,13 @@ saveName = args.saveName
 
 
 try:
-    elltt,ntt = np.loadtxt(args.tt,unpack=True)
+    elltt,ntt = np.loadtxt(args.tt,usecols=[0,1],unpack=True)
     noise_func_tt = interp1d(elltt,ntt,bounds_error=False,fill_value=np.inf)
 except:
     noise_func_tt = None
 
 try:
-    ellee,nee = np.loadtxt(args.pp,unpack=True)
+    ellee,nee = np.loadtxt(args.pp,usecols=[0,1],unpack=True)
     noise_func_ee = interp1d(ellee,nee,bounds_error=False,fill_value=np.inf)
 except:
     noise_func_ee = None
@@ -69,7 +69,7 @@ pellmin,pellmax = list_from_config(Config,expName,'pellrange')
 
 if (noise_func_tt is not None):
     fnTT = cosmology.noise_pad_infinity(noise_func_tt,tellmin,tellmax)
-if (noise_func_tt is not None):
+if (noise_func_ee is not None):
     fnEE = cosmology.noise_pad_infinity(noise_func_ee,pellmin,pellmax)
     
 

--- a/input/params.ini
+++ b/input/params.ini
@@ -42,8 +42,8 @@ pellrange = 2,500
 # Make minimum variance combination of the estimators below. Does not include covariance
 # Use ET instead of TE since it has less noise. You could include TE, but the covariance with ET
 # might be non-negligible. For most experiments of interest, either TT or EB dominates anyway.
-#polList = TT,EB,ET,TB,EE
-polList = EB,EE
+polList = TT,EB,ET,TB,EE
+#polList = EB,EE
 
 
 # The frequency in GHz of the reconstruction channel
@@ -573,7 +573,18 @@ alpha = -4.7,-3.8
 tellrange = 300,3000
 pellrange = 100,5000
 
+[SO-v3-goal]
 
+beams = 7.4,5.1,2.2,1.4,1.,0.9
+noises = 52.0853286,26.78674042,5.80379376,6.25023943,14.88152246,37.20380614
+freqs = 27.,39.,93.,145.,225.,280.
+lmax = 8000.
+fsky = 0.4
+lknee = 3400.,330
+alpha = -4.7,-3.8
+
+tellrange = 300,3000
+pellrange = 100,5000
 
 [NamExp]
 


### PR DESCRIPTION
-There was a small copy and paste bug in bin/lensing.py for creating Nell_EEs if they weren't specified
-Specified that loadtxt should read the 1st two cols of the arbitrary noise files, just incase the files have more than 2 cols